### PR TITLE
Fix missing dependency when not installing globally via npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "d3-dsv": "^0.1.5",
+    "js-yaml": "^3.3.0",
     "parse-json": "^2.0.0",
     "queue-async": "^1.0.7",
     "shapefile": "^0.3.0",
@@ -39,10 +40,8 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "chalk": "^1.0.0",
     "documentation": "2.1.0-alpha1",
     "istanbul": "^0.3.17",
-    "js-yaml": "^3.3.0",
     "mocha": "^2.2.5",
     "standard": "^4.5.1"
   }


### PR DESCRIPTION
js-yaml is required, at least with node v0.12.6 and v4.0.0, but dev
dependencies aren't installed when doing something like:
  npm install indian-ocean --save

Afterward, even a basic require('indian-ocean') fails when js-yaml is
not found.  Tested without js-yaml installed globally.
//  Basic example that will fail:
  var util = require('util');
  var io = require('indian-ocean');
  console.log(util.inspect(io));
//

Also npm complains because chalk was listed in both normal and
dev dependencies.  It ignored chalk ^1.0.0 from dev, so that was
removed, leaving only ^1.1.1 from 'dependencies' to use instead.
