### PR TITLE
Remove src to allow es6 modules to work

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@ docs/
 documentation.yml
 .travis.yml
 rollup.config*
-src/


### PR DESCRIPTION
I'm using rollup and the `modules` points to `index.node.js` which in turn points to files in `src` which are then missing due to this config. At least I think that's what's happening.